### PR TITLE
Match JSON even when Piwik does not send an array

### DIFF
--- a/piwik.js
+++ b/piwik.js
@@ -83,8 +83,9 @@ app.api = function( vars, cb ) {
 				data = buf.toString('utf8').trim()
 				
 				// callback
-				data = data.trim()
-				if( data.substr(0,1) == '[' && data.substr(-1,1) == ']' ) {
+				var left = /\[|\{/
+				var right = /\]|\}/
+				if( left.test( data.substr(0,1) ) && right.test( data.substr(-1,1) ) ) {
 					cb( JSON.parse( data ) )
 				}
 				


### PR DESCRIPTION
Added regexps to match both [ and {. 
Also removed a duplicate trim().
