### PR TITLE
Do not call `request.end()` with `null`

### DIFF
--- a/piwik.js
+++ b/piwik.js
@@ -213,7 +213,7 @@ function talk (props, cb) {
   });
 
   // run it
-  request.end (props.body || null);
+  request.end (props.body);
 }
 
 // module


### PR DESCRIPTION
`null` is not a valid data to send to `request.end()` therefore it breaks with (at least) browserify implementation.

If `props.body` is undefined, it will simply be ignored.